### PR TITLE
Add security check for secret leaks

### DIFF
--- a/.github/workflows/secrets_security.yaml
+++ b/.github/workflows/secrets_security.yaml
@@ -1,0 +1,15 @@
+name: Secrets Security
+on: pull_request
+
+jobs:
+  gitleaks:
+    name: Gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,6 @@
+# Define the Docker image you want to check
+IMAGE_NAME=zricethezav/gitleaks
+PROJECT_PATH=/project
+
+docker pull zricethezav/gitleaks:latest
+docker run -v $(pwd):$PROJECT_PATH zricethezav/gitleaks:latest protect --staged --source="$PROJECT_PATH"


### PR DESCRIPTION
Este `Pull Request` objetiva adicionar de uma verificação contra vazamento de informações sensíveis no código.
Utiliza o `gitleaks` para fazer essa verificação.

Para tanto, foi criado um script de `pre-commit` no `husky` que faz um `pull` da `docker image` do `gitleaks` e em seguida utiliza a imagem para rodar o comando de verificação, conforme exemplificado no `readme do gitleaks`: https://github.com/gitleaks/gitleaks?tab=readme-ov-file.

A escolha pela instalação da `docker image` ao invés de outras alternativas foi devido à praticidade da abordagem, tornando desnecessário que os desenvolvedores se preocupem com configurar a instalação correta em suas diferentes máquinas.

Por fim, também foi criado uma `Github Action` para verificar vazamentos no `CI`, novamente seguindo o exemplificado no `readme do gitleaks`.